### PR TITLE
refactor: redis util 책임분리 완료

### DIFF
--- a/DirectoryGuide.md
+++ b/DirectoryGuide.md
@@ -1,0 +1,32 @@
+##  ✅ Feature(도메인) 별로 관리합니다.
+##  ✅ 엔티티는 Common에서 관리합니다.
+
+``````
+src/main/java/com/yourcompany/project
+├── common
+│   └── entity
+│       ├── User.java
+│       ├── Address.java
+│       └── ...
+├── feature1
+│   ├── controller
+│   │   └── Feature1Controller.java
+│   ├── service
+│   │   └── Feature1Service.java
+│   ├── repository
+│   │   └── Feature1Repository.java
+│   └── dto
+│       └── Feature1RequestDto.java
+├── feature2
+│   ├── controller
+│   ├── service
+│   ├── repository
+│   └── dto
+├── feature3
+│   ├── controller
+│   ├── service
+│   ├── repository
+│   └── dto
+└── config
+└── WebConfig.java
+```

--- a/src/main/java/org/example/honorsparkingbe/config/RedisConfig.java
+++ b/src/main/java/org/example/honorsparkingbe/config/RedisConfig.java
@@ -3,52 +3,41 @@ package org.example.honorsparkingbe.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.RequiredArgsConstructor;
 import org.example.honorsparkingbe.dto.NotificationQueueItem;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@RequiredArgsConstructor
 public class RedisConfig {
 
-  @Value("${spring.data.redis.port}")
-  public int port;
+  private final RedisProperties redisProperties;
 
-  @Value("${spring.data.redis.host}")
-  public String host;
 
   @Bean
-  @Primary // 250514
-  public RedisConnectionFactory redisConnectionFactory() {
-    return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+  public LettuceConnectionFactory redisConnectionFactory() {
+    RedisStandaloneConfiguration standaloneConfig = new RedisStandaloneConfiguration();
+    standaloneConfig.setHostName(redisProperties.getHost());
+    standaloneConfig.setPort(redisProperties.getPort());
+    standaloneConfig.setPassword(RedisPassword.of(redisProperties.getPassword()));
+
+    LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+        .build();
+
+    return new LettuceConnectionFactory(standaloneConfig, clientConfig);
   }
-
-
-@Bean
-@Primary
-public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
-  RedisTemplate<String, Object> template = new RedisTemplate<>();
-  template.setConnectionFactory(redisConnectionFactory);
-
-  // Key 및 해시 키 직렬화기는 String 기반으로
-  template.setKeySerializer(new StringRedisSerializer());
-  template.setHashKeySerializer(new StringRedisSerializer());
-
-  // 값 및 해시 값 직렬화기는 JDK 직렬화로
-  JdkSerializationRedisSerializer jdkSerializer = new JdkSerializationRedisSerializer();
-  template.setValueSerializer(jdkSerializer);
-  template.setHashValueSerializer(jdkSerializer);
-
-  return template;
-}
 
 
   @Bean
@@ -72,5 +61,16 @@ public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisC
     template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
 
     return template;
+  }
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate() {
+    final RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setHashKeySerializer(new GenericToStringSerializer<>(Object.class));
+    redisTemplate.setHashValueSerializer(new JdkSerializationRedisSerializer());
+    redisTemplate.setValueSerializer(new StringRedisSerializer());
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    return redisTemplate;
   }
 }

--- a/src/main/java/org/example/honorsparkingbe/service/SyncInoutService.java
+++ b/src/main/java/org/example/honorsparkingbe/service/SyncInoutService.java
@@ -1,15 +1,13 @@
 package org.example.honorsparkingbe.service;
 
-import java.time.LocalDateTime;
-import java.util.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.example.honorsparkingbe.domain.entity.*;
 import org.example.honorsparkingbe.domain.entity.CarEntity;
+import org.example.honorsparkingbe.domain.entity.ExpoEntity;
 import org.example.honorsparkingbe.domain.entity.MemberEntity;
 import org.example.honorsparkingbe.domain.entity.ParkingHistoryEntity;
 import org.example.honorsparkingbe.domain.entity.ParkingZoneEntity;
@@ -22,13 +20,13 @@ import org.example.honorsparkingbe.dto.request.SyncInoutRequest;
 import org.example.honorsparkingbe.dto.request.SyncInoutRequest.Inout;
 import org.example.honorsparkingbe.dto.response.SyncInoutResponse;
 import org.example.honorsparkingbe.dto.response.SyncInoutResponse.ParkingEntry;
-import org.example.honorsparkingbe.repository.internal.*;
 import org.example.honorsparkingbe.repository.internal.CarRepository;
+import org.example.honorsparkingbe.repository.internal.ExpoRepository;
 import org.example.honorsparkingbe.repository.internal.MemberRepository;
 import org.example.honorsparkingbe.repository.internal.ParkingHistoryRepository;
 import org.example.honorsparkingbe.repository.internal.ParkingZoneRepository;
 import org.example.honorsparkingbe.repository.internal.PayRepository;
-import org.example.honorsparkingbe.util.RedisUtil;
+import org.example.honorsparkingbe.util.NotificationQueueRedisUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,8 +41,7 @@ public class SyncInoutService {
   private final MemberRepository memberRepository;
   private final PayRepository payRepository;
   private final ExpoRepository expoRepository;
-  private final ExpoPushService expoPushService;
-  private final RedisUtil redisUtil;
+  private final NotificationQueueRedisUtil redisUtil;
 
   @Transactional
   public SyncInoutResponse syncParkingHistory(SyncInoutRequest request) {
@@ -159,8 +156,9 @@ public class SyncInoutService {
 
       // expo 토큰이 있는지 확인(여러 기기 처리를 위해 List로 변경)
       List<ExpoEntity> expoList = expoRepository.findAllByUserId(userId);
-      if (expoList.isEmpty()) continue;
-
+      if (expoList.isEmpty()) {
+        continue;
+      }
 
       // 츨차시간 여부를 확인하여 입차, 출차 결정
       boolean isEntry = entity.getExitTime() == null;
@@ -169,17 +167,17 @@ public class SyncInoutService {
 
       for (ExpoEntity expoEntity : expoList) {
         pushQueueItems.add(NotificationQueueItem.builder()
-                .notiChannel(NotiChannel.PUSH)
-                .notiEventType(isEntry ? NotiEventType.ENTRY : NotiEventType.EXIT)
-                .carNumber(entity.getCarEntity().getCarNumber())
-                .entranceTime(entity.getEntranceTime())
-                .pushToken(expoEntity.getPushToken())
-                .notiTitle(title)
-                .notiBody(body)
-                .retryCount(0)
-                .build());
-        }
+            .notiChannel(NotiChannel.PUSH)
+            .notiEventType(isEntry ? NotiEventType.ENTRY : NotiEventType.EXIT)
+            .carNumber(entity.getCarEntity().getCarNumber())
+            .entranceTime(entity.getEntranceTime())
+            .pushToken(expoEntity.getPushToken())
+            .notiTitle(title)
+            .notiBody(body)
+            .retryCount(0)
+            .build());
       }
+    }
     redisUtil.notiEnqueueAll(pushQueueItems);
   }
 

--- a/src/main/java/org/example/honorsparkingbe/util/NotificationQueueRedisUtil.java
+++ b/src/main/java/org/example/honorsparkingbe/util/NotificationQueueRedisUtil.java
@@ -1,0 +1,36 @@
+package org.example.honorsparkingbe.util;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.example.honorsparkingbe.dto.NotificationQueueItem;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationQueueRedisUtil {
+
+  private static final String QUEUE_KEY = "notification:queue";
+  private final RedisTemplate<String, NotificationQueueItem> notificationRedisTemplate;
+
+  // 1. 단일 객체 enqueue
+  public void notiEnqueue(NotificationQueueItem value) {
+    notificationRedisTemplate.opsForList().rightPush(QUEUE_KEY, value);
+  }
+
+  // 2. 여러 객체 한 번에 enqueue
+  public void notiEnqueueAll(List<NotificationQueueItem> values) {
+    notificationRedisTemplate.opsForList().rightPushAll(QUEUE_KEY, values);
+  }
+
+  // 3. 하나 dequeue (왼쪽 pop)
+  public NotificationQueueItem notiDequeue() {
+    return notificationRedisTemplate.opsForList().leftPop(QUEUE_KEY);
+  }
+
+  // 4. 큐 길이 확인 (선택)
+  public Long notiQueueSize() {
+    return notificationRedisTemplate.opsForList().size(QUEUE_KEY);
+  }
+
+}

--- a/src/main/java/org/example/honorsparkingbe/util/RedisUtil.java
+++ b/src/main/java/org/example/honorsparkingbe/util/RedisUtil.java
@@ -1,10 +1,8 @@
 package org.example.honorsparkingbe.util;
 
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.example.honorsparkingbe.dto.NotificationQueueItem;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
@@ -15,10 +13,6 @@ public class RedisUtil {
   private static final String QUEUE_KEY = "notification:queue";
   private final RedisTemplate<String, Object> redisTemplate;
   private final RedisTemplate<String, NotificationQueueItem> notificationRedisTemplate;
-
-  // RedisTemplate을 사용하는 경우 RedisConnectionFactory를 설정하는 방법
-  private final RedisConnectionFactory redisConnectionFactory;
-
 
   public void set(String key, Object value, long timeout, TimeUnit unit) {
     redisTemplate.opsForValue().set(key, value, timeout, unit);
@@ -36,24 +30,4 @@ public class RedisUtil {
     return Boolean.TRUE.equals(redisTemplate.hasKey(key));
   }
 
-  // Notification 큐(notification:queue) 관련 기능
-  // 1. 단일 객체 enqueue
-  public void notiEnqueue(NotificationQueueItem value) {
-    notificationRedisTemplate.opsForList().rightPush(QUEUE_KEY, value);
-  }
-
-  // 2. 여러 객체 한 번에 enqueue
-  public void notiEnqueueAll(List<NotificationQueueItem> values) {
-    notificationRedisTemplate.opsForList().rightPushAll(QUEUE_KEY, values);
-  }
-
-  // 3. 하나 dequeue (왼쪽 pop)
-  public NotificationQueueItem notiDequeue() {
-    return notificationRedisTemplate.opsForList().leftPop(QUEUE_KEY);
-  }
-
-  // 4. 큐 길이 확인 (선택)
-  public Long notiQueueSize() {
-    return notificationRedisTemplate.opsForList().size(QUEUE_KEY);
-  }
 }

--- a/src/main/java/org/example/honorsparkingbe/util/squeduler/RedisNotificationWorker.java
+++ b/src/main/java/org/example/honorsparkingbe/util/squeduler/RedisNotificationWorker.java
@@ -8,7 +8,7 @@ import org.example.honorsparkingbe.domain.enums.NotiEventType;
 import org.example.honorsparkingbe.dto.NotificationQueueItem;
 import org.example.honorsparkingbe.service.ExpoPushService;
 import org.example.honorsparkingbe.service.KakaoNotificationTalkService;
-import org.example.honorsparkingbe.util.RedisUtil;
+import org.example.honorsparkingbe.util.NotificationQueueRedisUtil;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class RedisNotificationWorker {
 
-  private final RedisUtil redisUtil;
+  private final NotificationQueueRedisUtil redisUtil;
   private final KakaoNotificationTalkService kakaoNotificationTalkService;
   private final Logger logger = Logger.getLogger(RedisNotificationWorker.class.getName());
   private final ExpoPushService expoPushService;
@@ -69,7 +69,7 @@ public class RedisNotificationWorker {
     data.put("uri", "/parking");
 
     expoPushService.sendPushNotification(
-            item.getPushToken(), item.getNotiTitle(), item.getNotiBody(), data
+        item.getPushToken(), item.getNotiTitle(), item.getNotiBody(), data
     );
   }
 

--- a/src/test/java/org/example/honorsparkingbe/unit/service/SyncInoutServiceTest.java
+++ b/src/test/java/org/example/honorsparkingbe/unit/service/SyncInoutServiceTest.java
@@ -37,7 +37,7 @@ import org.example.honorsparkingbe.repository.internal.ParkingHistoryRepository;
 import org.example.honorsparkingbe.repository.internal.ParkingZoneRepository;
 import org.example.honorsparkingbe.repository.internal.PayRepository;
 import org.example.honorsparkingbe.service.SyncInoutService;
-import org.example.honorsparkingbe.util.RedisUtil;
+import org.example.honorsparkingbe.util.NotificationQueueRedisUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -69,7 +69,7 @@ public class SyncInoutServiceTest {
   @Mock
   private PayRepository payRepository;
   @Mock
-  private RedisUtil redisUtil;
+  private NotificationQueueRedisUtil redisUtil;
 
   CarEntity entryOnlyCar;
   CarEntity exitedCar;

--- a/src/test/java/org/example/honorsparkingbe/unit/util/RedisNotificationWorkerTest.java
+++ b/src/test/java/org/example/honorsparkingbe/unit/util/RedisNotificationWorkerTest.java
@@ -13,7 +13,7 @@ import org.example.honorsparkingbe.domain.enums.NotiChannel;
 import org.example.honorsparkingbe.domain.enums.NotiEventType;
 import org.example.honorsparkingbe.dto.NotificationQueueItem;
 import org.example.honorsparkingbe.service.KakaoNotificationTalkService;
-import org.example.honorsparkingbe.util.RedisUtil;
+import org.example.honorsparkingbe.util.NotificationQueueRedisUtil;
 import org.example.honorsparkingbe.util.squeduler.RedisNotificationWorker;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,7 +29,7 @@ public class RedisNotificationWorkerTest {
   private RedisNotificationWorker worker;
 
   @Mock
-  private RedisUtil redisUtil;
+  private NotificationQueueRedisUtil redisUtil;
 
   @Mock
   private KakaoNotificationTalkService kakaoNotificationTalkService;

--- a/src/test/java/org/example/honorsparkingbe/unit/util/RedisUtilTest.java
+++ b/src/test/java/org/example/honorsparkingbe/unit/util/RedisUtilTest.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 import org.example.honorsparkingbe.domain.enums.NotiChannel;
 import org.example.honorsparkingbe.domain.enums.NotiEventType;
 import org.example.honorsparkingbe.dto.NotificationQueueItem;
+import org.example.honorsparkingbe.util.NotificationQueueRedisUtil;
 import org.example.honorsparkingbe.util.RedisUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -53,6 +54,8 @@ public class RedisUtilTest {
 
   @Autowired
   private RedisUtil redisUtil;
+  @Autowired
+  private NotificationQueueRedisUtil notiUtil;
 
   @BeforeAll
   static void setUp() {
@@ -121,7 +124,7 @@ public class RedisUtilTest {
     Long BeforeSize = forVerifyRedisTemplate.opsForList().size("notification:queue");
 
     // When
-    redisUtil.notiEnqueue(
+    notiUtil.notiEnqueue(
         NotificationQueueItem.builder()
             .phoneNumber("01012341234")
             .carNumber("123가1234")
@@ -171,7 +174,7 @@ public class RedisUtilTest {
     List<NotificationQueueItem> items = List.of(item1, item2, item3);
 
     // When
-    redisUtil.notiEnqueueAll(items);
+    notiUtil.notiEnqueueAll(items);
 
     // Then
     Long AfterSize = forVerifyRedisTemplate.opsForList().size("notification:queue");
@@ -196,7 +199,7 @@ public class RedisUtilTest {
     forVerifyRedisTemplate.opsForList().rightPush("notification:queue", item);
 
     // When
-    NotificationQueueItem dequeuedItem = redisUtil.notiDequeue();
+    NotificationQueueItem dequeuedItem = notiUtil.notiDequeue();
 
     //Then
     assertNotNull(dequeuedItem);
@@ -212,7 +215,7 @@ public class RedisUtilTest {
   @DisplayName("Redis Notification Queue enqueue get Size 테스트")
   void testNotificationQueueGetSize() {
     //Given
-    Long BeforeSize = redisUtil.notiQueueSize();
+    Long BeforeSize = notiUtil.notiQueueSize();
 
     NotificationQueueItem item = NotificationQueueItem.builder()
         .phoneNumber("01033333333")
@@ -225,7 +228,7 @@ public class RedisUtilTest {
         .rightPushAll("notification:queue", List.of(item, item, item, item));
 
     //When
-    Long AfterSize = redisUtil.notiQueueSize();
+    Long AfterSize = notiUtil.notiQueueSize();
 
     //Then
     assertNotNull(BeforeSize);


### PR DESCRIPTION
기존에 RedisUtil은 알람 저장소와 기본 저장소의 로직을 한꺼번에 관리하고 잇었고 이를 책임분리 해야겠다고 생각했습니다.

따라서 분리를 완료했습니다.