### PR TITLE
fix: Security에러 핸들링시에 sessiongID가 없으면 중간에 에러처리해서 로그인 로직자체가 안돌아감

### DIFF
--- a/src/main/java/org/example/honorsparkingbe/config/SecurityConfig.java
+++ b/src/main/java/org/example/honorsparkingbe/config/SecurityConfig.java
@@ -4,7 +4,6 @@ package org.example.honorsparkingbe.config;
  * Spring Security 설정 클래스 - 접근 권한 설정, 로그인 로그아웃 및 세션 관리, CSRF 비활성화 등
  */
 
-import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.Set;
 import org.example.honorsparkingbe.security.ApiKeyAuthFilter;
@@ -41,7 +40,7 @@ public class SecurityConfig {
   private static final Set<String> CSRF_REQUIRED_PROFILES = Set.of("prod", "performanceTest");
 
   public SecurityConfig(CustomOAuth2UserService customOAuth2UserService, Environment environment,
-      ApiKeyAuthFilter apiKeyAuthFilter ,AesUtil aesUtil) {
+      ApiKeyAuthFilter apiKeyAuthFilter, AesUtil aesUtil) {
 
     this.customOAuth2UserService = customOAuth2UserService;
     this.activeProfile = environment.getProperty("spring.profiles.active",
@@ -69,20 +68,20 @@ public class SecurityConfig {
         .cors(cors -> cors.configurationSource(corsConfigurationSource())) // CORS 활성화
         .authorizeHttpRequests((auth) -> auth
             .requestMatchers(
-                    "/api/v1/csrf-token",
-                    "/api/v1/",
-                    "/api/v1/auth/login/**",
-                    "/api/v1/auth/join",
-                    "/api/v1/phone-auth/send",
-                    "/api/v1/phone-auth/verify",
-                    "/confirm",
-                    "/swagger-ui/**",
-                    "/v3/api-docs/**",
-                    "api/v1/auth/check-authId",
-                    "api/v1/expo/**",
-                    "api/v1/auth/issue-cookie",
-                    "api/v1/auth/custom-session-login",
-                    "/api/v1/parking/nonmember" // 비회원 차량조회
+                "/api/v1/csrf-token",
+                "/api/v1/",
+                "/api/v1/auth/login/**",
+                "/api/v1/auth/join",
+                "/api/v1/phone-auth/send",
+                "/api/v1/phone-auth/verify",
+                "/confirm",
+                "/swagger-ui/**",
+                "/v3/api-docs/**",
+                "api/v1/auth/check-authId",
+                "api/v1/expo/**",
+                "api/v1/auth/issue-cookie",
+                "api/v1/auth/custom-session-login",
+                "/api/v1/parking/nonmember" // 비회원 차량조회
             ).permitAll()
             .requestMatchers("/api/v1/", "/api/v1/auth/login/**", "/api/v1/auth/join", "/confirm",
                 "/swagger-ui/**", "/v3/api-docs/**", "api/v1/auth/check-authId",
@@ -92,14 +91,39 @@ public class SecurityConfig {
             .anyRequest().authenticated()
         )
         .addFilterBefore(apiKeyAuthFilter,
-            UsernamePasswordAuthenticationFilter.class) // API Key 필터 추가
+            UsernamePasswordAuthenticationFilter.class); // API Key 필터 추가
 
-        .exceptionHandling(exception -> exception
-            .authenticationEntryPoint((request, response, authException) -> {
-              response.sendError(HttpServletResponse.SC_UNAUTHORIZED,
-                  "Unauthorized"); // 비인가 접근 시 401 반환
-            })
-        );
+//        .exceptionHandling(exception -> exception
+//            .authenticationEntryPoint((request, response, authException) -> {
+//              // 인증 실패 로그 출력
+//              System.out.println("❌ Unauthorized access detected: " + authException.getMessage());
+//
+//              // 요청 정보 출력
+//              System.out.println("🔗 Request URI: " + request.getRequestURI());
+//              System.out.println("➡️ Request Method: " + request.getMethod());
+//
+//              // 요청 헤더 출력
+//              System.out.println("📦 Request Headers:");
+//              request.getHeaderNames().asIterator().forEachRemaining(headerName -> {
+//                System.out.println("  " + headerName + ": " + request.getHeader(headerName));
+//              });
+//
+//              Cookie[] cookies = request.getCookies();
+//              System.out.println("🍪 Request Cookies:");
+//              if (cookies != null) {
+//                for (Cookie cookie : cookies) {
+//                  System.out.println("  " + cookie.getName() + " = " + cookie.getValue());
+//                }
+//              } else {
+//                System.out.println("  (No Cookies)");
+//              }
+//
+//              // 인증 예외 스택 출력
+//              authException.printStackTrace();
+//
+//              // 클라이언트에 401 반환
+//              response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+//            })
 
     http
         .formLogin((formLogin) -> formLogin
@@ -111,7 +135,8 @@ public class SecurityConfig {
         .oauth2Login((oauth2) -> oauth2
             .loginPage("/login")
             //.defaultSuccessUrl("/api/v1/session/info", true) // 소셜 로그인 성공 후 이동 경로
-            .successHandler(new CustomOAuth2LoginSuccessHandler(aesUtil)) // OAuth2 성공 핸들러 등록 (json 반환을 위해)
+            .successHandler(
+                new CustomOAuth2LoginSuccessHandler(aesUtil)) // OAuth2 성공 핸들러 등록 (json 반환을 위해)
             .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
                 .userService(customOAuth2UserService)));
 

--- a/src/main/java/org/example/honorsparkingbe/controller/CsrfController.java
+++ b/src/main/java/org/example/honorsparkingbe/controller/CsrfController.java
@@ -20,39 +20,41 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1")
 public class CsrfController {
 
-  static String CSRF_KEY = "XSRF-TOKEN";
-
   @GetMapping("/csrf-token")
   public Map<String, String> getCsrfToken(HttpServletRequest request,
       HttpServletResponse response) {
+    // 세션을 강제로 생성 (없을 경우)
     request.getSession();
 
+    // Spring Security가 제공하는 CsrfToken
     CsrfToken csrfToken = (CsrfToken) request.getAttribute("_csrf");
 
-    Cookie[] cookies = request.getCookies();
-    boolean alreadyExists = false;
-    if (cookies != null) {
-      for (Cookie cookie : cookies) {
-        if (CSRF_KEY.equals(cookie.getName())) {
-          alreadyExists = true;
+    // 이미 쿠키로 세팅되어 있다면 중복 설정하지 않음
+    boolean tokenCookieExists = false;
+    if (request.getCookies() != null) {
+      for (Cookie cookie : request.getCookies()) {
+        if ("XSRF-TOKEN".equals(cookie.getName())) {
+          tokenCookieExists = true;
           break;
         }
       }
     }
 
-    if (!alreadyExists) {
-      ResponseCookie cookie = ResponseCookie.from(CSRF_KEY, csrfToken.getToken())
+    // XSRF-TOKEN 쿠키가 없다면 생성
+    if (!tokenCookieExists) {
+      ResponseCookie cookie = ResponseCookie.from("XSRF-TOKEN", csrfToken.getToken())
           .path("/")
           .httpOnly(false)
           .secure(true)
           .sameSite("None")
           .build();
 
-      response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+      response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
+    // 프론트에서 헤더로 보낼 때 필요한 정보 반환
     return Map.of(
-        "headerName", csrfToken.getHeaderName(),
+        "headerName", csrfToken.getHeaderName(), // 일반적으로 X-CSRF-TOKEN
         "parameterName", csrfToken.getParameterName(),
         "token", csrfToken.getToken()
     );

--- a/src/main/java/org/example/honorsparkingbe/security/CustomFormLoginSuccessHandler.java
+++ b/src/main/java/org/example/honorsparkingbe/security/CustomFormLoginSuccessHandler.java
@@ -4,19 +4,19 @@ package org.example.honorsparkingbe.security;
  * 일반 로그인 성공 핸들러
  */
 
-import org.springframework.security.core.Authentication;
-import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
-
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 
 public class CustomFormLoginSuccessHandler implements AuthenticationSuccessHandler {
 
-    @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
-        // 상태 코드 200만 반환
-        response.setStatus(HttpServletResponse.SC_OK);
-    }
+  @Override
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+      Authentication authentication) throws IOException {
+    // 상태 코드 200만 반환
+    response.setStatus(HttpServletResponse.SC_OK);
+  }
 }
 


### PR DESCRIPTION
# 1. Secruity ExceptionHandler에서 에러발생
SessionId가 쿠키내에 없어도 세션이 없다고 인식하는 경우 발생(파이썬 클라이언트에서) 따라서 전역 예외처리를 제외함